### PR TITLE
Add xalan dependency management element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.log4j>1.2.14</version.log4j>
         <version.slf4j>1.7.2</version.slf4j>
         <version.byteman>2.1.3</version.byteman>
-
+        <version.xalan>2.7.1</version.xalan>
         <path.tools_jar>${java.home}/../lib/tools.jar</path.tools_jar>
         <!--
         <path.tools_jar>/usr/lib/jvm/java-6-openjdk/lib/tools.jar</path.tools_jar>
@@ -85,6 +85,11 @@
                 <version>${version.spec}</version>
                 <type>pom</type>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>${version.xalan}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Resolution for the following error which appears during build: 

Failure to find xalan:xalan:jar:2.7.1.jbossorg-2 in http://repo.maven.apache.org/maven2 was cached in the local repository

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-extension-byteman/3)
<!-- Reviewable:end -->
