### PR TITLE
Updated README to run wildfly as remote contianer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ If you have not provided `chameleonTarget` then it will take default value provi
 
 While running the tests from an IDE, variable `${path.tools_jar}` in `arquillian.xml` is not defined, as it's only defined in Maven build. Thus the execution results with `NoClassDefFoundError`. One possible way to overcome this problem is to hardcode Byteman settings in `arquillian.xml` pointing to the `tools.jar` file from your JDK. See commented out section in `arquillian.xml`.
 
+To Run tests in remote container make sure that you started your server with following VM arguments:
+```java
+-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:${path.tools_jar}
+```
+
+You can do this from your IDE, go to edit launch configuration for WildFly server, append above parameter in VM arguments & restart server. Run tests as follows:
+```bash
+$ mvn test -Darq.container.chameleon.configuration.chameleonTarget="wildfly:10.1.0.Final:remote"
+```
+
 Notes
 ------
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-extension-byteman/9)
<!-- Reviewable:end -->
