### PR TITLE
Fixed multiple Byteman agent installation issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,13 @@
   </dependencies>
 
   <build>
+    <testResources>
+        <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+        </testResource>
+    </testResources>
+  
     <plugins>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
@@ -195,8 +202,8 @@
               </includes>
               <rules>
                 <rule>
-                  <pattern>org.jboss.byteman.**</pattern>
-                  <result>org.jboss.arquillian.extension.byteman.@1</result>
+                  <pattern>org.jboss.byteman.agent.submit.**</pattern>
+                  <result>org.jboss.arquillian.extension.byteman.agent.submit.@1</result>
                 </rule>
               </rules>
             </configuration>


### PR DESCRIPTION
#### Short description of what this resolves:

Repairs Byteman agent auto installation feature. Agent is tried to install multiple times causing test error.

In class `AgentInstaller` this logic checks that Byteman agent has been loaded yet:
```java
try {
    // Not only load it, but also attempt to check firstTime variable, since in embedded containers this might be the same jvm
    Class<?> mainClass =
        Thread.currentThread().getContextClassLoader().loadClass("org.jboss.byteman.agent.Main");
    if (!(Boolean) mainClass.getDeclaredField("firstTime").get(null)) {
        return;
    }
} catch (ClassNotFoundException e) {
    // Agent not loaded yet, move on
}
```
But method loadClass always throws ClassNotFoundException because the string `org.jboss.byteman.agent.Main` is rewritten by jarjar-maven-plugin to `org.jboss.arquillian.extension.byteman.agent.Main`. Obviously there is no such class.

#### Changes proposed in this pull request:

I've modified the jarjar-maven-plugin configuration to avoid the rewrite and NPE.

**Fixes**: #2 
