### PR TITLE
Updating version of byteman to 4.0.2,arquillian 1.4.0 and fixing follow-up issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@
   <!-- Properties -->
   <properties>
     <!-- Versioning -->
-    <version.arquillian_core>1.1.13.Final</version.arquillian_core>
+    <version.arquillian_core>1.4.0.Final</version.arquillian_core>
     <version.arquillian_chameleon>1.0.0.Beta1</version.arquillian_chameleon>
     <version.javaee_spec>1.0.3.Final</version.javaee_spec>
-    <version.byteman>3.0.8</version.byteman>
+    <version.byteman>4.0.2</version.byteman>
     <version.jarjar>1.9</version.jarjar>
     <version.xalan>2.7.2</version.xalan>
     <path.tools_jar>${java.home}/../lib/tools.jar</path.tools_jar>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <version.xalan>2.7.2</version.xalan>
     <path.tools_jar>${java.home}/../lib/tools.jar</path.tools_jar>
     <!-- <path.tools_jar>/usr/lib/jvm/java-6-openjdk/lib/tools.jar</path.tools_jar> -->
+    <arq.server.jvm.args.debug></arq.server.jvm.args.debug>
   </properties>
 
   <dependencyManagement>
@@ -170,6 +171,7 @@
         <configuration>
           <systemProperties>
             <path.tools_jar>${path.tools_jar}</path.tools_jar>
+            <arq.server.jvm.args.debug>${arq.server.jvm.args.debug}</arq.server.jvm.args.debug>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
           <excludes>
@@ -205,5 +207,21 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+        <profile>
+          <id>debug</id>
+          <activation>
+            <property>
+              <name>debug</name>
+            </property>
+          </activation>
+          <properties>
+            <arq.server.jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</arq.server.jvm.args.debug>
+          </properties>
+        </profile>
+      <profile>
+      </profile>
+  </profiles>
 </project>
 

--- a/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/AbstractRuleInstaller.java
+++ b/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/AbstractRuleInstaller.java
@@ -3,14 +3,6 @@ package org.jboss.arquillian.extension.byteman.impl.common;
 import java.util.List;
 import java.util.logging.Logger;
 
-import org.jboss.arquillian.core.api.annotation.Observes;
-import org.jboss.arquillian.core.spi.event.Event;
-import org.jboss.arquillian.test.spi.event.suite.After;
-import org.jboss.arquillian.test.spi.event.suite.AfterClass;
-import org.jboss.arquillian.test.spi.event.suite.Before;
-import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
-import org.jboss.arquillian.test.spi.event.suite.TestEvent;
-
 /**
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
@@ -21,9 +13,7 @@ public abstract class AbstractRuleInstaller {
     public static final String CLASS_KEY_PREFIX = "Class:";
     public static final String METHOD_KEY_PREFIX = "Method:";
 
-    protected abstract List<ExecContext> getExecContexts(Event event);
-
-    private static void install(String prefix, String script, ExecContext context) {
+    protected static void install(String prefix, String script, ExecContext context) {
         if (script != null) {
             try {
                 SubmitUtil.install(generateKey(prefix), script, context);
@@ -36,7 +26,7 @@ public abstract class AbstractRuleInstaller {
         }
     }
 
-    private static void uninstall(String prefix, String script, ExecContext context) {
+    protected static void uninstall(String prefix, String script, ExecContext context) {
         if (script != null) {
             try {
                 SubmitUtil.uninstall(generateKey(prefix), script, context);
@@ -48,42 +38,9 @@ public abstract class AbstractRuleInstaller {
         }
     }
 
-    public void installClass(@Observes BeforeClass event) {
-        for (ExecContext context : getExecContexts(event)) {
-            String script = ExtractScriptUtil.extract(context, event);
-            install(CLASS_KEY_PREFIX, script, context);
-        }
-    }
-
-    public void uninstallClass(@Observes AfterClass event) {
-        for (ExecContext context : getExecContexts(event)) {
-            String script = ExtractScriptUtil.extract(context, event);
-            uninstall(generateKey(CLASS_KEY_PREFIX), script, context);
-        }
-    }
-
-    protected abstract boolean shouldRun(TestEvent event);
-
-    public void installMethod(@Observes Before event) {
-        if (!shouldRun(event)) {
-            return;
-        }
-
-        for (ExecContext context : getExecContexts(event)) {
-            String script = ExtractScriptUtil.extract(context, event);
-            install(METHOD_KEY_PREFIX, script, context);
-        }
-    }
-
-    public void uninstallMethod(@Observes After event) {
-        if (!shouldRun(event)) {
-            return;
-        }
-
-        for (ExecContext context : getExecContexts(event)) {
-            String script = ExtractScriptUtil.extract(context, event);
-            uninstall(METHOD_KEY_PREFIX, script, context);
-        }
+    protected static boolean isInstalled(String scriptName, ExecContext context) {
+        List<String> scriptNames = SubmitUtil.listInstalled(context);
+        return scriptNames.contains(generateKey(scriptName));
     }
 
     private static String generateKey(String prefix) {

--- a/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/ExtractScriptUtil.java
+++ b/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/ExtractScriptUtil.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.jboss.arquillian.extension.byteman.api.BMRule;
 import org.jboss.arquillian.extension.byteman.api.BMRules;
 import org.jboss.arquillian.extension.byteman.api.ExecType;
+import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.arquillian.test.spi.event.suite.ClassLifecycleEvent;
 import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
 
@@ -35,11 +36,16 @@ import org.jboss.arquillian.test.spi.event.suite.TestLifecycleEvent;
  */
 public final class ExtractScriptUtil {
     public static String extract(ExecContext context, ClassLifecycleEvent event) {
-        BMRule rule = event.getTestClass().getAnnotation(BMRule.class);
-        BMRules rules = event.getTestClass().getAnnotation(BMRules.class);
+        String script = extract(context, event.getTestClass());
+        context.validate(event);
+        return script;
+    }
+
+    public static String extract(ExecContext context, TestClass testClass) {
+        BMRule rule = testClass.getAnnotation(BMRule.class);
+        BMRules rules = testClass.getAnnotation(BMRules.class);
 
         String script = createRules(context, rule, rules);
-        context.validate(event);
         return script;
     }
 

--- a/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/SubmitUtil.java
+++ b/src/main/java/org/jboss/arquillian/extension/byteman/impl/common/SubmitUtil.java
@@ -17,7 +17,9 @@
  */
 package org.jboss.arquillian.extension.byteman.impl.common;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.jboss.byteman.agent.submit.ScriptText;
 import org.jboss.byteman.agent.submit.Submit;
@@ -28,22 +30,37 @@ import org.jboss.byteman.agent.submit.Submit;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
  */
-public class SubmitUtil {
-    public static void install(String key, String script, ExecContext context) {
+final class SubmitUtil {
+	static List<String> listInstalled(ExecContext context) {
+		try {
+			Submit submit = new Submit(context.getAddress(), context.getPort());
+			List<String> scriptNames = new ArrayList<>();
+			for(ScriptText st: submit.getAllScripts()) {
+				scriptNames.add(st.getFileName());
+			}
+			return scriptNames;
+		} catch (Exception e) {
+			throw new SubmitException("Could not list installed scripts for context " + context, e);
+		}
+	}
+
+    static void install(String key, String script, ExecContext context) {
         try {
             Submit submit = new Submit(context.getAddress(), context.getPort());
             submit.addScripts(Arrays.asList(new ScriptText(key, script)));
         } catch (Exception e) {
-            throw new SubmitException("Could not install script from file", e);
+            throw new SubmitException("Could not install script '"
+                + script + "' for context " + context, e);
         }
     }
 
-    public static void uninstall(String key, String script, ExecContext context) {
+    static void uninstall(String key, String script, ExecContext context) {
         try {
             Submit submit = new Submit(context.getAddress(), context.getPort());
             submit.deleteScripts(Arrays.asList(new ScriptText(key, script)));
         } catch (Exception e) {
-            throw new SubmitException("Could not uninstall script from file", e);
+            throw new SubmitException("Could not uninstall script "
+                + script + " for context " + context, e);
         }
     }
 }

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -13,17 +13,16 @@
   <container qualifier="chameleon" default="true">
     <configuration>
       <property name="chameleonTarget">wildfly:10.1.0.Final:managed</property>
-      <!-- -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y  -->
       <!-- <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:/usr/lib/jvm/java-6-openjdk/lib/tools.jar</property> -->
 
       <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman
-        -Xbootclasspath/a:${path.tools_jar}
+        -Xbootclasspath/a:${path.tools_jar} ${arq.server.jvm.args.debug} -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
       </property>
     </configuration>
   </container>
 
   <extension qualifier="byteman">
     <property name="autoInstallAgent">true</property>
-    <property name="agentProperties">org.jboss.byteman.verbose=true</property>
+    <property name="agentProperties">org.jboss.byteman.verbose=true,prop:org.jboss.byteman.debug=true</property>
   </extension>
 </arquillian>


### PR DESCRIPTION
The PR is follow-up to the https://github.com/arquillian/arquillian-extension-byteman/pull/10. With the fix I wanted to move to the new  byteman 4.x.
But with changing Byteman version there came fix https://issues.jboss.org/browse/BYTEMAN-349 which caused removing static resources when rules are uninstalled. That fix revealed issue of this extension which removes rules for class when method finishes. That's caused by fact that `@AfterClass` event is for container handlers invoked each time the method finishes. This is "a correct" behaviour but a bit unexpected.
The proposed fix here uses `@StopClassContainers` at client side which calls the managed container to clean.

Fixes: https://github.com/arquillian/arquillian-extension-byteman/issues/11