### PR TITLE
Add support for JDK 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: java
 
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - jdk: oraclejdk8
+    - jdk: oraclejdk9
 
 install: true
 
 script:
   - ./mvnw clean install
-

--- a/README.md
+++ b/README.md
@@ -104,8 +104,17 @@ If you want to do this from Eclipse IDE, go to "Edit Launch Configuration" of yo
 Notes
 ------
 
-When using `autoInstallAgent` with application server such as WildFly, the `com.sun.tools.attach` package has to be exposed as a system package and `tools.jar` added to the bootstrap classpath.
+When using `autoInstallAgent` with application server such as WildFly, a number of JDK version-dependent parameters need to be passed to the JVM:
+
+For JDK 8 and below: the `com.sun.tools.attach` and `org.jboss.byteman` packages have to be exposed as system packages and `tools.jar` added to the bootstrap classpath.
 
 ```xml
 <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:${path.tools_jar}</property>
+```
+
+
+For JDK 9 and above: the `org.jboss.byteman` package has to be exposed as a system package and `-Djdk.attach.allowAttachSelf=true` passed as a system property.
+
+```xml
+<property name="javaVmArguments">-Djboss.modules.system.pkgs=org.jboss.byteman -Djdk.attach.allowAttachSelf=true</property>
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For JDK 8 and below: the `com.sun.tools.attach` and `org.jboss.byteman` packages
 ```
 
 
-For JDK 9 and above: the `org.jboss.byteman` package has to be exposed as a system package and `-Djdk.attach.allowAttachSelf=true` passed as a system property.
+For JDK 9 and above: the `com.sun.tools.attach` and `org.jboss.byteman` packages have to be exposed as a system packages and `-Djdk.attach.allowAttachSelf=true` passed as a system property.
 
 ```xml
 <property name="javaVmArguments">-Djboss.modules.system.pkgs=org.jboss.byteman -Djdk.attach.allowAttachSelf=true</property>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
           <properties>
               <!-- required for VM attach under JDK 9-->
               <surefire.argline>-Djdk.attach.allowAttachSelf=true</surefire.argline>
-              <byteman.agent.support>-Djboss.modules.system.pkgs=org.jboss.byteman -Djdk.attach.allowAttachSelf=true</byteman.agent.support>
+              <byteman.agent.support>-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman-Djdk.attach.allowAttachSelf=true</byteman.agent.support>
           </properties>
           <dependencies/>
       </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <!-- Versioning -->
     <version.arquillian_core>1.4.1.Final</version.arquillian_core>
-    <version.arquillian_chameleon>1.0.0.CR5</version.arquillian_chameleon>
+    <version.arquillian_chameleon>1.0.0.CR6</version.arquillian_chameleon>
     <version.javaee_spec>1.1.1.Final</version.javaee_spec>
     <version.byteman>4.0.6</version.byteman>
     <version.jarjar>1.9</version.jarjar>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,7 @@
     <version.byteman>4.0.6</version.byteman>
     <version.jarjar>1.9</version.jarjar>
     <version.xalan>2.7.2</version.xalan>
-    <path.tools_jar>${java.home}/../lib/tools.jar</path.tools_jar>
-    <!-- <path.tools_jar>/usr/lib/jvm/java-6-openjdk/lib/tools.jar</path.tools_jar> -->
+    <surefire.argline />
     <arq.server.jvm.args.debug />
   </properties>
 
@@ -102,15 +101,7 @@
       <artifactId>shrinkwrap-spi</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.6.0</version>
-      <scope>system</scope>
-      <systemPath>${path.tools_jar}</systemPath>
-    </dependency>
-
-    <!-- org.joss.byteman -->
+    <!-- org.jboss.byteman -->
 
     <dependency>
       <groupId>org.jboss.byteman</groupId>
@@ -175,8 +166,9 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>${surefire.argline}</argLine>
           <systemProperties>
-            <path.tools_jar>${path.tools_jar}</path.tools_jar>
+            <arq.server.jvm.args.byteman>${byteman.agent.support}</arq.server.jvm.args.byteman>
             <arq.server.jvm.args.debug>${arq.server.jvm.args.debug}</arq.server.jvm.args.debug>
           </systemProperties>
           <runOrder>alphabetical</runOrder>
@@ -185,8 +177,7 @@
           </excludes>
         </configuration>
       </plugin>
-      <!-- We need to jarjar this, since WildFly grabs all org.jboss.byteman
-          as system packages -->
+      <!-- We need to jarjar this, since WildFly grabs all org.jboss.byteman as system packages -->
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>jarjar-maven-plugin</artifactId>
@@ -227,19 +218,75 @@
   </build>
 
   <profiles>
-        <profile>
-          <id>debug</id>
+      <!-- three Byteman-related profiles for configuring use of Byteman on different platforms/JDKs-->
+      <profile>
+          <id>use-toolsjar-jigsaw</id>
           <activation>
-            <property>
-              <name>debug</name>
-            </property>
+              <jdk>[1.9,)</jdk>
           </activation>
           <properties>
-            <arq.server.jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</arq.server.jvm.args.debug>
+              <!-- required for VM attach under JDK 9-->
+              <surefire.argline>-Djdk.attach.allowAttachSelf=true</surefire.argline>
+              <byteman.agent.support>-Djboss.modules.system.pkgs=org.jboss.byteman -Djdk.attach.allowAttachSelf=true</byteman.agent.support>
           </properties>
-        </profile>
-      <profile>
+          <dependencies/>
       </profile>
+
+      <profile>
+          <id>use-toolsjar-default</id>
+          <activation>
+              <file>
+                  <exists>${java.home}/../lib/tools.jar</exists>
+              </file>
+          </activation>
+          <properties>
+              <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
+              <byteman.agent.support>-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:${tools.jar}</byteman.agent.support>
+          </properties>
+          <dependencies>
+              <dependency>
+                  <groupId>com.sun</groupId>
+                  <artifactId>tools</artifactId>
+                  <version>1.8</version>
+                  <scope>system</scope>
+                  <systemPath>${tools.jar}</systemPath>
+              </dependency>
+          </dependencies>
+      </profile>
+
+      <profile>
+          <id>use-toolsjar-osx</id>
+          <activation>
+              <file>
+                  <exists>${java.home}/../Classes/classes.jar</exists>
+              </file>
+          </activation>
+          <properties>
+              <tools.jar>${java.home}/../Classes/classes.jar</tools.jar>
+              <byteman.agent.support>-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:${tools.jar}</byteman.agent.support>
+          </properties>
+          <dependencies>
+              <dependency>
+                  <groupId>com.sun</groupId>
+                  <artifactId>tools</artifactId>
+                  <version>1.8</version>
+                  <scope>system</scope>
+                  <systemPath>${tools.jar}</systemPath>
+              </dependency>
+          </dependencies>
+      </profile>
+
+       <profile>
+         <id>debug</id>
+         <activation>
+           <property>
+             <name>debug</name>
+           </property>
+         </activation>
+         <properties>
+           <arq.server.jvm.args.debug>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</arq.server.jvm.args.debug>
+         </properties>
+       </profile>
   </profiles>
 </project>
 

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
 
   <container qualifier="chameleon" default="true">
     <configuration>
-      <property name="chameleonTarget">wildfly:10.1.0.Final:managed</property>
+      <property name="chameleonTarget">wildfly:11.0.0.Final:managed</property>
       <!-- <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:/usr/lib/jvm/java-6-openjdk/lib/tools.jar</property> -->
 
       <property name="javaVmArguments">${arq.server.jvm.args.byteman} ${arq.server.jvm.args.debug} -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true</property>

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -12,7 +12,7 @@
 
   <container qualifier="chameleon" default="true">
     <configuration>
-      <property name="chameleonTarget">wildfly:11.0.0.Final:managed</property>
+      <property name="chameleonTarget">wildfly:16.0.0.Final:managed</property>
       <!-- <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:/usr/lib/jvm/java-6-openjdk/lib/tools.jar</property> -->
 
       <property name="javaVmArguments">${arq.server.jvm.args.byteman} ${arq.server.jvm.args.debug} -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true</property>

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -15,9 +15,7 @@
       <property name="chameleonTarget">wildfly:10.1.0.Final:managed</property>
       <!-- <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman -Xbootclasspath/a:/usr/lib/jvm/java-6-openjdk/lib/tools.jar</property> -->
 
-      <property name="javaVmArguments">-Djboss.modules.system.pkgs=com.sun.tools.attach,org.jboss.byteman
-        -Xbootclasspath/a:${path.tools_jar} ${arq.server.jvm.args.debug} -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true
-      </property>
+      <property name="javaVmArguments">${arq.server.jvm.args.byteman} ${arq.server.jvm.args.debug} -Dorg.jboss.byteman.debug=true -Dorg.jboss.byteman.verbose=true</property>
     </configuration>
   </container>
 


### PR DESCRIPTION
#### Short description of what this resolves:
This adds in support for arquillian-byteman-extension to run under JDK 9. 
The main issue here is that the org.jboss.modules.system.pkgs differs under JDK9 as well as the -Xboothclasspath needs to be absent. The agent installer also needs to be able to auto-attach to the JVM which requires -Djdk.attach.allowAttachSelf=true.

#### Changes proposed in this pull request:
- add in profiles to support JDK versions  <= 8 and >= 9 
- modify default arquillian.xml to accept a general property containing all Byteman agent parameters that is now supplied in the pom
- update the docs to indicate when running under JDK 9, you need to pass a different set of arguments

**Fixes**: #25
